### PR TITLE
[discord] add gif cropping support

### DIFF
--- a/Objective-C/TOCropViewController/Categories/UIImage+Animated.h
+++ b/Objective-C/TOCropViewController/Categories/UIImage+Animated.h
@@ -1,0 +1,38 @@
+//
+//  UIImage+Animated.h
+//  TOCropViewController
+//
+//  Created by Neal Manaktola on 8/5/21.
+//  Copyright © 2021 Tim Oliver. All rights reserved.
+//
+
+#ifndef UIImage_Animated_h
+#define UIImage_Animated_h
+
+#import <UIKit/UIKit.h>
+
+@class TOImageFrame;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIImage (TOAnimated)
+
+/// Creates an animated image from NSData
+/// @param data
++ (nullable UIImage *)animatedImageFromData:(nullable NSData *)data;
+
+
+/// Creates an animated image from NSData
+/// @param frames
++ (nullable UIImage *)animatedImageFromFrames:(nullable NSArray<TOImageFrame *> *)frames;
+
+
+/// Creates an array of image frames from an animated UI
+- (nullable NSArray<TOImageFrame *> *)frames;
+
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* UIImage_Animated_h */

--- a/Objective-C/TOCropViewController/Categories/UIImage+Animated.m
+++ b/Objective-C/TOCropViewController/Categories/UIImage+Animated.m
@@ -1,0 +1,187 @@
+//
+//  UIImage+Animated.m
+//
+//  Copyright 2015-2020 Timothy Oliver. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "UIImage+Animated.h"
+#import "TOImageFrame.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+
+@implementation UIImage (Animated)
+
++ (NSTimeInterval)frameDurationAtIndex:(NSUInteger)index source:(CGImageSourceRef)source {
+    NSTimeInterval frameDuration = 0.1;
+    NSDictionary *options = @{
+        (__bridge NSString *)kCGImageSourceShouldCacheImmediately : @(YES),
+        (__bridge NSString *)kCGImageSourceShouldCache : @(YES) // Always cache to reduce CPU usage
+    };
+    CFDictionaryRef cfFrameProperties = CGImageSourceCopyPropertiesAtIndex(source, index, (__bridge CFDictionaryRef)options);
+    NSDictionary *frameProperties = (__bridge NSDictionary*)cfFrameProperties;
+    NSDictionary *gifProperties = frameProperties[(NSString*)kCGImagePropertyGIFDictionary];
+    
+    NSNumber *delayTimeUnclampedProp = gifProperties[(NSString*)kCGImagePropertyGIFUnclampedDelayTime];
+    if (delayTimeUnclampedProp != nil) {
+        frameDuration = [delayTimeUnclampedProp doubleValue];
+    } else {
+        NSNumber *delayTimeProp = gifProperties[(NSString*)kCGImagePropertyGIFDelayTime];
+        if (delayTimeProp != nil) {
+            frameDuration = [delayTimeProp doubleValue];
+        }
+    }
+    
+    // Many annoying ads specify a 0 duration to make an image flash as quickly as possible.
+    // We follow Firefox's behavior and use a duration of 100 ms for any frames that specify
+    // a duration of <= 10 ms. See <rdar://problem/7689300> and <http://webkit.org/b/36082>
+    // for more information.
+    if (frameDuration < 0.011) {
+        frameDuration = 0.1;
+    }
+    
+    return frameDuration;
+}
+
+
++ (nullable UIImage *)animatedImageFromData:(nullable NSData *)data {
+    if (!data) {
+        return nil;
+    }
+    
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    if (!source) {
+        return nil;
+    }
+    
+    size_t count = CGImageSourceGetCount(source);
+    
+    // Decode as static image
+    if (count <= 1) {
+        return [[UIImage alloc] initWithData:data];
+    } else {
+        NSMutableArray<TOImageFrame *> *frames = [NSMutableArray array];
+        
+        for (size_t i = 0; i < count; i++) {
+            CGImageRef cgImage = CGImageSourceCreateImageAtIndex(source, i, NULL);
+            
+            // Get image and duration
+            UIImage *image = [UIImage imageWithCGImage:cgImage];
+            NSTimeInterval duration = [UIImage frameDurationAtIndex:i source:source];
+            
+            [frames addObject:[TOImageFrame frameWithImage:image duration:duration]];
+            CGImageRelease(cgImage);
+        }
+        return [UIImage animatedImageFromFrames:frames];
+    }
+}
+
++ (nullable UIImage *)animatedImageFromFrames:(nullable NSArray<TOImageFrame *> *)frames {
+    NSUInteger frameCount = frames.count;
+    
+    if (frameCount == 0) {
+        return nil;
+    }
+    
+    UIImage *animatedImage;
+    NSUInteger durations[frameCount];
+    for (size_t i = 0; i < frameCount; i++) {
+        durations[i] = frames[i].duration * 1000;
+    }
+    
+    NSUInteger const gcd = gcdArray(frameCount, durations);
+    __block NSUInteger totalDuration = 0;
+    NSMutableArray<UIImage *> *animatedImages = [NSMutableArray arrayWithCapacity:frameCount];
+    [frames enumerateObjectsUsingBlock:^(TOImageFrame * _Nonnull frame, NSUInteger idx, BOOL * _Nonnull stop) {
+        UIImage *image = frame.image;
+        NSUInteger duration = frame.duration * 1000;
+        totalDuration += duration;
+        NSUInteger repeatCount;
+        if (gcd) {
+            repeatCount = duration / gcd;
+        } else {
+            repeatCount = 1;
+        }
+        for (size_t i = 0; i < repeatCount; ++i) {
+            [animatedImages addObject:image];
+        }
+    }];
+    
+    animatedImage = [UIImage animatedImageWithImages:animatedImages duration:totalDuration / 1000.f];
+    
+    return animatedImage;
+}
+
+- (nullable NSArray<TOImageFrame *> *)frames {
+    NSMutableArray<TOImageFrame *> *frames = [NSMutableArray array];
+    
+    NSArray<UIImage *> *animatedImages = self.images;
+    NSInteger frameCount = animatedImages.count;
+        
+    if (frameCount == 0) {
+        return nil;
+    }
+    NSTimeInterval avgDuration = self.duration / frameCount;
+    if (avgDuration == 0) {
+        avgDuration = 0.1;
+    }
+    __block NSUInteger repeatCount = 1;
+    __block UIImage *previousImage = animatedImages.firstObject;
+    
+    [animatedImages enumerateObjectsUsingBlock:^(UIImage * _Nonnull image, NSUInteger idx, BOOL * _Nonnull stop) {
+        //ignore first
+        if (idx == 0) {
+            return;
+        }
+        
+        if ([image isEqual: previousImage]) {
+            repeatCount++;
+        } else {
+            TOImageFrame *frame = [TOImageFrame frameWithImage:previousImage duration:avgDuration * repeatCount];
+            [frames addObject:frame];
+            repeatCount = 1;
+        }
+        previousImage = image;
+    }];
+    
+    TOImageFrame *frame = [TOImageFrame frameWithImage:previousImage duration:avgDuration * repeatCount];
+    [frames addObject:frame];
+    return frames;
+}
+
+static NSUInteger gcd(NSUInteger a, NSUInteger b) {
+    NSUInteger c;
+    while (a != 0) {
+        c = a;
+        a = b % a;
+        b = c;
+    }
+    return b;
+}
+
+static NSUInteger gcdArray(size_t const count, NSUInteger const * const values) {
+    if (count == 0) {
+        return 0;
+    }
+    NSUInteger result = values[0];
+    for (size_t i = 1; i < count; ++i) {
+        result = gcd(values[i], result);
+    }
+    return result;
+}
+
+@end

--- a/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
@@ -21,6 +21,8 @@
 //  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import "UIImage+CropRotate.h"
+#import "TOImageFrame.h"
+#import "UIImage+Animated.h"
 
 @implementation UIImage (CropRotate)
 
@@ -31,8 +33,8 @@
             alphaInfo == kCGImageAlphaPremultipliedFirst || alphaInfo == kCGImageAlphaPremultipliedLast);
 }
 
-- (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
-{
+
+- (UIImage *)crop:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular {
     UIImage *croppedImage = nil;
     UIGraphicsBeginImageContextWithOptions(frame.size, !self.hasAlpha && !circular, self.scale);
     {
@@ -77,4 +79,21 @@
     return [UIImage imageWithCGImage:croppedImage.CGImage scale:self.scale orientation:UIImageOrientationUp];
 }
 
+- (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
+{
+    if (self.images) {
+        NSArray<TOImageFrame *> * frames = [self frames];
+        NSMutableArray<TOImageFrame*> * croppedFrames = [NSMutableArray arrayWithCapacity:frames.count];
+
+        [frames enumerateObjectsUsingBlock:^(TOImageFrame * _Nonnull imageFrame, NSUInteger idx, BOOL * _Nonnull stop) {
+            UIImage* croppedImage = [imageFrame.image crop:frame angle:angle circularClip:circular];
+            TOImageFrame* croppedImageFrame = [TOImageFrame frameWithImage:croppedImage duration:imageFrame.duration];
+            [croppedFrames addObject:croppedImageFrame];
+        }];
+        
+        return [UIImage animatedImageFromFrames:croppedFrames];
+    }
+
+    return [self crop:frame angle:angle circularClip:circular];
+}
 @end

--- a/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
@@ -81,6 +81,7 @@
 
 - (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
 {
+    NSLog(@"testing-croppedImageWithFrame");
     if (self.images) {
         NSArray<TOImageFrame *> * frames = [self frames];
         NSMutableArray<TOImageFrame*> * croppedFrames = [NSMutableArray arrayWithCapacity:frames.count];

--- a/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
+++ b/Objective-C/TOCropViewController/Categories/UIImage+CropRotate.m
@@ -81,7 +81,6 @@
 
 - (UIImage *)croppedImageWithFrame:(CGRect)frame angle:(NSInteger)angle circularClip:(BOOL)circular
 {
-    NSLog(@"testing-croppedImageWithFrame");
     if (self.images) {
         NSArray<TOImageFrame *> * frames = [self frames];
         NSMutableArray<TOImageFrame*> * croppedFrames = [NSMutableArray arrayWithCapacity:frames.count];

--- a/Objective-C/TOCropViewController/Models/TOImageFrame.h
+++ b/Objective-C/TOCropViewController/Models/TOImageFrame.h
@@ -1,0 +1,40 @@
+//
+//  TOImageFrame.h
+//  TOCropViewControllerExample
+//
+//  Created by Neal Manaktola on 8/5/21.
+//  Copyright © 2021 Tim Oliver. All rights reserved.
+//
+
+#ifndef TOImageFrame_h
+#define TOImageFrame_h
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+/**
+ This class is used to represent a frame in an animated image. Note, this class was borrowed from SDWebImage
+ 
+ */
+@interface TOImageFrame : NSObject
+
+/**
+ The image of current frame. You should not set an animated image.
+ */
+@property (nonatomic, strong, readonly, nonnull) UIImage *image;
+/**
+ The duration of current frame to be displayed. The number is seconds but not milliseconds. You should not set this to zero.
+ */
+@property (nonatomic, readonly, assign) NSTimeInterval duration;
+
+/**
+ Create a frame instance with specify image and duration
+ @param image current frame's image
+ @param duration current frame's duration
+ @return frame instance
+ */
++ (nonnull instancetype)frameWithImage:(nonnull UIImage *)image duration:(NSTimeInterval)duration;
+
+@end
+
+#endif /* TOImageFrame_h */

--- a/Objective-C/TOCropViewController/Models/TOImageFrame.m
+++ b/Objective-C/TOCropViewController/Models/TOImageFrame.m
@@ -1,0 +1,42 @@
+//
+//  TOImageFrame.m
+//
+//  Copyright 2015-2020 Timothy Oliver. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TOImageFrame.h"
+
+@interface TOImageFrame ()
+
+@property (nonatomic, strong, readwrite, nonnull) UIImage *image;
+@property (nonatomic, readwrite, assign) NSTimeInterval duration;
+
+@end
+
+@implementation TOImageFrame
+
++ (instancetype)frameWithImage:(UIImage *)image duration:(NSTimeInterval)duration {
+    TOImageFrame *frame = [[TOImageFrame alloc] init];
+    frame.image = image;
+    frame.duration = duration;
+    
+    return frame;
+}
+
+@end

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -103,10 +103,12 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     return self;
 }
 
+
 - (instancetype)initWithImage:(UIImage *)image
 {
     return [self initWithCroppingStyle:TOCropViewCroppingStyleDefault image:image];
 }
+
 
 - (void)viewDidLoad
 {

--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -103,7 +103,6 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     return self;
 }
 
-
 - (instancetype)initWithImage:(UIImage *)image
 {
     return [self initWithCroppingStyle:TOCropViewCroppingStyleDefault image:image];

--- a/TOCropViewControllerExample.xcodeproj/project.pbxproj
+++ b/TOCropViewControllerExample.xcodeproj/project.pbxproj
@@ -94,6 +94,12 @@
 		2F5062F31F53E31F00AA9F14 /* TOCropViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 22DB4D831B234CFA008B8466 /* TOCropViewController.m */; };
 		2F5062F41F53E32800AA9F14 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 223424751ABBC0CD00BBC2B1 /* ViewController.m */; };
 		2F5062F51F53E32D00AA9F14 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 223424771ABBC0CD00BBC2B1 /* Main.storyboard */; };
+		331A867426BCD46100F00A7E /* UIImage+Animated.h in Headers */ = {isa = PBXBuildFile; fileRef = 331A867326BCD46100F00A7E /* UIImage+Animated.h */; };
+		331A867B26BCDDCE00F00A7E /* UIImage+Animated.m in Sources */ = {isa = PBXBuildFile; fileRef = 331A867A26BCDDCE00F00A7E /* UIImage+Animated.m */; };
+		331A868526BCDF2A00F00A7E /* TOImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 331A868426BCDF2900F00A7E /* TOImageFrame.m */; };
+		331A868E26BD867000F00A7E /* TOImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 331A868426BCDF2900F00A7E /* TOImageFrame.m */; };
+		331A869326BD869D00F00A7E /* TOImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 331A868426BCDF2900F00A7E /* TOImageFrame.m */; };
+		331A869826BD86DF00F00A7E /* UIImage+Animated.m in Sources */ = {isa = PBXBuildFile; fileRef = 331A867A26BCDDCE00F00A7E /* UIImage+Animated.m */; };
 		FE3E0E3A21098448004DAE93 /* TOCropViewConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 220C8E9F21062DD300A9B25D /* TOCropViewConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
@@ -201,6 +207,10 @@
 		22F7331B259B71C400956847 /* TOCropViewControllerExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TOCropViewControllerExample.entitlements; sourceTree = "<group>"; };
 		22F7331C259B71C400956847 /* TOCropViewControllerExample-Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "TOCropViewControllerExample-Extension.entitlements"; sourceTree = "<group>"; };
 		2F5062DC1F53E2D900AA9F14 /* TOCropViewControllerExample-Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "TOCropViewControllerExample-Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		331A867326BCD46100F00A7E /* UIImage+Animated.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Animated.h"; sourceTree = "<group>"; };
+		331A867926BCD9F200F00A7E /* TOImageFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOImageFrame.h; sourceTree = "<group>"; };
+		331A867A26BCDDCE00F00A7E /* UIImage+Animated.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Animated.m"; sourceTree = "<group>"; };
+		331A868426BCDF2900F00A7E /* TOImageFrame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TOImageFrame.m; sourceTree = "<group>"; };
 		3AADDE231CA5C43400AE0129 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/TOCropViewControllerLocalizable.strings; sourceTree = "<group>"; };
 		6AE313501C47DAA200894C5B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		6AE313511C47DAA200894C5B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/TOCropViewControllerLocalizable.strings; sourceTree = "<group>"; };
@@ -323,6 +333,8 @@
 			children = (
 				220C8EAB2106344D00A9B25D /* UIImage+CropRotate.h */,
 				220C8EAA2106344D00A9B25D /* UIImage+CropRotate.m */,
+				331A867326BCD46100F00A7E /* UIImage+Animated.h */,
+				331A867A26BCDDCE00F00A7E /* UIImage+Animated.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -448,6 +460,8 @@
 				22DB4D9D1B234D4F008B8466 /* TOActivityCroppedImageProvider.m */,
 				22BF961E1B2CD017009F4785 /* TOCroppedImageAttributes.h */,
 				22BF961F1B2CD017009F4785 /* TOCroppedImageAttributes.m */,
+				331A867926BCD9F200F00A7E /* TOImageFrame.h */,
+				331A868426BCDF2900F00A7E /* TOImageFrame.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -482,6 +496,7 @@
 				144B8CD21D22CD650085D774 /* TOActivityCroppedImageProvider.h in Headers */,
 				FE3E0E3A21098448004DAE93 /* TOCropViewConstants.h in Headers */,
 				144B8CD31D22CD650085D774 /* TOCroppedImageAttributes.h in Headers */,
+				331A867426BCD46100F00A7E /* UIImage+Animated.h in Headers */,
 				144B8CD61D22CD650085D774 /* TOCropScrollView.h in Headers */,
 				144B8CD51D22CD650085D774 /* TOCropOverlayView.h in Headers */,
 			);
@@ -516,6 +531,7 @@
 				144B8CC51D22CAFF0085D774 /* Frameworks */,
 				144B8CC61D22CAFF0085D774 /* Headers */,
 				144B8CC71D22CAFF0085D774 /* Resources */,
+				331A866126BC3C9900F00A7E /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -605,6 +621,7 @@
 				2F5062D81F53E2D900AA9F14 /* Sources */,
 				2F5062D91F53E2D900AA9F14 /* Frameworks */,
 				2F5062DA1F53E2D900AA9F14 /* Resources */,
+				331A866E26BC3E3B00F00A7E /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -767,10 +784,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				331A868526BCDF2A00F00A7E /* TOImageFrame.m in Sources */,
 				220C8EAD2106344D00A9B25D /* UIImage+CropRotate.m in Sources */,
 				144B8CDA1D22CD730085D774 /* TOCropViewControllerTransitioning.m in Sources */,
 				144B8CDB1D22CD730085D774 /* TOActivityCroppedImageProvider.m in Sources */,
 				144B8CDC1D22CD730085D774 /* TOCroppedImageAttributes.m in Sources */,
+				331A867B26BCDDCE00F00A7E /* UIImage+Animated.m in Sources */,
 				144B8CDE1D22CD730085D774 /* TOCropOverlayView.m in Sources */,
 				144B8CDF1D22CD730085D774 /* TOCropScrollView.m in Sources */,
 				144B8CE01D22CD730085D774 /* TOCropToolbar.m in Sources */,
@@ -791,6 +810,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				331A869826BD86DF00F00A7E /* UIImage+Animated.m in Sources */,
+				331A869326BD869D00F00A7E /* TOImageFrame.m in Sources */,
 				22DB4D9B1B234D07008B8466 /* TOCropView.m in Sources */,
 				223424761ABBC0CD00BBC2B1 /* ViewController.m in Sources */,
 				22BF96201B2CD017009F4785 /* TOCroppedImageAttributes.m in Sources */,
@@ -846,6 +867,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				331A868E26BD867000F00A7E /* TOImageFrame.m in Sources */,
 				2236AB4A1F595960005C5098 /* ShareViewController.m in Sources */,
 				2F5062EC1F53E31F00AA9F14 /* TOActivityCroppedImageProvider.m in Sources */,
 				2F5062EF1F53E31F00AA9F14 /* TOCropOverlayView.m in Sources */,


### PR DESCRIPTION
This adds GIF cropping support to the crop controller.

The main change here is that when an image is cropped, all frames are expanded and cropped, and then combined together.
A good portion of the code inside UIImage+Animated.m was taken from SDWebImage which handles the encoding/decoding of gifs